### PR TITLE
Fixed missing callback on gitignore renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 1.1.0 (2019-05-16)
+
+
+### Bug Fixes
+
+* .gitignore not generated ([#7](https://github.com/postlight/nodejs-typescript-kit/issues/7)) ([fb8ab2f](https://github.com/postlight/nodejs-typescript-kit/commit/fb8ab2f))
+* Callback error fix for renaming .gitignore ([913d107](https://github.com/postlight/nodejs-typescript-kit/commit/913d107))
+* circleci config ([93cb54d](https://github.com/postlight/nodejs-typescript-kit/commit/93cb54d))
+* ignore test files ([d7331d6](https://github.com/postlight/nodejs-typescript-kit/commit/d7331d6))
+* js tests ([48d9fd4](https://github.com/postlight/nodejs-typescript-kit/commit/48d9fd4))
+* linting ([2b314c9](https://github.com/postlight/nodejs-typescript-kit/commit/2b314c9))
+* repo name ([144492d](https://github.com/postlight/nodejs-typescript-kit/commit/144492d))
+
+
+### Features
+
+* add CircleCi ([130d78d](https://github.com/postlight/nodejs-typescript-kit/commit/130d78d))
+* add circleci config file ([3165f6b](https://github.com/postlight/nodejs-typescript-kit/commit/3165f6b))
+* add pre commit hooks ([#3](https://github.com/postlight/nodejs-typescript-kit/issues/3)) ([80973af](https://github.com/postlight/nodejs-typescript-kit/commit/80973af))
+* add tests ([5e26817](https://github.com/postlight/nodejs-typescript-kit/commit/5e26817))

--- a/cli.js
+++ b/cli.js
@@ -42,7 +42,11 @@ const editFiles = async projectName => {
 
   fs.rename(
     `${__dirname}/starter-kit/gitignore`,
-    `${__dirname}/starter-kit/.gitignore`
+    `${__dirname}/starter-kit/.gitignore`,
+    function (err) {
+      if (err) throw err;
+      console.log('renamed complete');
+    }
   );
 };
 

--- a/cli.js
+++ b/cli.js
@@ -45,7 +45,6 @@ const editFiles = async projectName => {
     `${__dirname}/starter-kit/.gitignore`,
     function (err) {
       if (err) throw err;
-      console.log('renamed complete');
     }
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-typescript-starter-kit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postlight/node-typescript-starter-kit",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "NodeJS - TypeScript Starter Kit",
   "author": "Postlight",
   "contributors": [
@@ -25,7 +25,9 @@
     "ESLint",
     "ES6"
   ],
-  "scripts": {},
+  "scripts": {
+    "release": "standard-version"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^2.4.2",


### PR DESCRIPTION
Fix for this error:
❯ npx @postlight/node-typescript-starter-kit my-awesome-project
npx: installed 21 in 3.903s

Creating a new starter kit in /Users/macbook/Sites/my-awesome-project

Callback must be a function. Received undefined