### PR TITLE
fix: issue where starter kit can only be run once

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,13 +40,15 @@ const editFiles = async projectName => {
   file.set('name', projectName);
   file.save();
 
-  fs.rename(
-    `${__dirname}/starter-kit/gitignore`,
-    `${__dirname}/starter-kit/.gitignore`,
-    function (err) {
-      if (err) throw err;
-    }
-  );
+  if (fs.existsSync(`${__dirname}/starter-kit/gitignore`)) {
+    fs.rename(
+      `${__dirname}/starter-kit/gitignore`,
+      `${__dirname}/starter-kit/.gitignore`,
+      function (err) {
+        if (err) throw err;
+      }
+    );
+  }
 };
 
 const checkDirectory = async () => {

--- a/cli.js
+++ b/cli.js
@@ -67,7 +67,13 @@ const checkDirectory = async () => {
   }
 };
 
-const successText = projectName => {
+const checkProjectName = async (projectPath) => {
+  if (fs.existsSync(projectPath)) {
+    throw `ERROR: Project already exists in directory:: ${projectPath}`;
+  }
+};
+
+const successText = (projectName) => {
   const successText = `Success! Created ${chalk.cyan(
     projectName
   )} at ${chalk.cyan(CURR_DIR)} 
@@ -94,6 +100,8 @@ const run = async () => {
   const projectName = await checkDirectory();
 
   const starterKitPath = `${__dirname}/starter-kit/`;
+
+  await checkProjectName(`${CURR_DIR}/${projectName}`);
 
   await editFiles(projectName);
 


### PR DESCRIPTION
**Changes:**
- Fixes issue where starter kit can only be run once. More information is inside [issue #29](https://github.com/postlight/nodejs-typescript-kit/issues/29).
- Also checks if project name exists already in the current directory. If it does, stop running the starter kit with an error. Previously it was erroring out since the directory already existed.


**Issue causing [#29](https://github.com/postlight/nodejs-typescript-kit/issues/29):** 
The cli file renames `gitignore` to `.gitignore` inside of `/starter-kit`. When the kit is run more than once, that file has already been renamed so it errors out.

**Fix:** 
Check if `gitignore` exists without the dot. If it doesn't, don't rename the file since it doesn't need it.
